### PR TITLE
Introduce empty arg in a PR

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -824,7 +824,7 @@ with pkgs;
   sea-orm-cli = callPackage ../development/tools/sea-orm-cli { };
 
   vcpkg-tool = callPackage ../by-name/vc/vcpkg-tool/package.nix {
-    fmt = fmt_10;
+    #fmt = fmt_10;
   };
 
   r3ctl = qt5.callPackage ../tools/misc/r3ctl { };


### PR DESCRIPTION
Tests https://github.com/NixOS/nixpkgs/pull/274591 and https://github.com/NixOS/nixpkgs/pull/272395 by making a PR to add a new empty non-auto-called attribute. Note that the base branch also has an empty non-auto-called attribute (https://github.com/tweag/nixpkgs/blob/1025f21c369a71e12aa1739a9f1c964ec620635e/pkgs/top-level/all-packages.nix#L27424), but this is not a CI error.