### PR TITLE
Test that a new package fails CI if not added to `pkgs/by-name`

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -122,6 +122,8 @@ with pkgs;
 
   nix-generate-from-cpan = callPackage ../../maintainers/scripts/nix-generate-from-cpan.nix { };
 
+  this-should-error = callPackage ../../maintainers/scripts/nix-generate-from-cpan.nix { };
+
   nixpkgs-lint = callPackage ../../maintainers/scripts/nixpkgs-lint.nix { };
 
   common-updater-scripts = callPackage ../common-updater/scripts.nix { };


### PR DESCRIPTION
A test against https://github.com/NixOS/nixpkgs/pull/281835 to make sure that https://github.com/NixOS/nixpkgs/pull/275539